### PR TITLE
Firefox Fix

### DIFF
--- a/src/tags/object/RichText/domManager.ts
+++ b/src/tags/object/RichText/domManager.ts
@@ -667,7 +667,6 @@ export default class DomManager {
     const text = String(selection);
 
     selection.removeAllRanges();
-    selection.removeRange(range);
 
     // restore previous selection
     for (const range of lastRanges) {


### PR DESCRIPTION
# Summary
When viewing label studio in firefox, we see a vague `Uncaught DOM Exception: Node was not found`.

The stack trace in the console is very unhelpful, but eventually I figured out which file this error was being thrown from. With a variation of commenting out code, try/catch blocks, and console log statements, i tracked down the offending function call. but since it is implemented as an interface in the ts code, "go to source" wasn't an option in my IDE. Enter the js debugger. After clicking through the call stack what felt like a thousand times, I finally got it to break on the exception that was being raised. this led me to the code I've deleted here. Basically, it seems the function is removing all objects from an array using the `removeAllRanges` function, and then, for reason unknowable, it then tries to remove an explicit range. From the best I can tell, this range was already removed by the `removeAllRanges` call, and so the `Node was not found` and thus could not be removed. Removing the excessive extra remove range call, firefox now seems to load just fine, and from local testing, Chrome is unaffected.

Issue: [DI-672](https://khanacademy.atlassian.net/browse/DI-672)

# Testing Plan

Going to build and deploy into ml-test, click around, and make sure things still work as expected. Because I'm not even close to react-fluent, I'm not totally sure what the possible footprint of this change is, but I'm planning to test the hotpath for users (ie: create project, create schema, import data, annotate, and export) and makes sure it "still works (tm)"


[DI-672]: https://khanacademy.atlassian.net/browse/DI-672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ