### PR TITLE
Adding scheduled sync to release branch

### DIFF
--- a/.github/actions/notify_slack/action.yml
+++ b/.github/actions/notify_slack/action.yml
@@ -1,0 +1,20 @@
+name: Notify Slack on workflow failure
+description: notifies infrastructure-data-alerts channel on workflow failure.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Notify slack on failure
+      if: failure()
+      uses: slackapi/slack-github-action@v1.23.0
+      with:
+        payload: |
+          {
+            "project": "${{ github.repository }}",
+            "workflow": "${{ github.workflow }}",
+            "status": "${{ job.status }}",
+            "build": "https://github.com/Khan/label-studio-frontend/actions/runs/${{ github.run_id }}"
+          }
+      env:
+        # Notifies the #infrastructure-data-alerts channel.
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/sync_to_release.yml
+++ b/.github/workflows/sync_to_release.yml
@@ -1,13 +1,30 @@
-name: 'TEST: Scheduled sync to release branch'
+name: 'Scheduled sync to release branch'
 
 on:
   # Allow manual syncing/testing.
   workflow_dispatch:
+  # Every Monday at 0600 UTC.
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
-      - name: Placeholder
+      - name: Check out release branch
+        uses: actions/checkout@v3
+        with:
+          # uses the `khan-actions-bot` Khan Org level user which was granted
+          # permissions to override branch protections.
+          token: ${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}
+          ref: release
+      - name: Merge master into release
         run: |
-          echo 'Placeholder for testing'
+          git config --global user.name 'khan-actions-bot'
+          git config --global user.email 'infrastructure-data@khanacademy.org'
+          git fetch --all --unshallow
+
+          git merge origin/master --no-edit -m 'Merge master into release branch in run id ${{github.run_id}}'
+          git push
+      - name: Notify Slack on failure
+        uses: ./.github/actions/notify_slack


### PR DESCRIPTION
## Summary:
Adding a weekly scheduled sync to merge the `master` branch into the `release` branch. This will run at 0600 UTC on Mondays and notify #infrastructure-data-alerts on failure.

Issue: DI-529

## Test plan:
- ran in workflow-testing branch. note: this failed because notify_slack isn't in the branch: https://github.com/Khan/label-studio-frontend/actions/runs/6201400961/job/16838024267