### PR TITLE
Updating PR sync to notify our backend repo

### DIFF
--- a/.github/actions/notify_slack/action.yml
+++ b/.github/actions/notify_slack/action.yml
@@ -1,6 +1,11 @@
 name: Notify Slack on workflow failure
 description: notifies infrastructure-data-alerts channel on workflow failure.
 
+inputs:
+  webhook_url:
+    description: "Slack webhook url"
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -17,4 +22,4 @@ runs:
           }
       env:
         # Notifies the #infrastructure-data-alerts channel.
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_URL: ${{ inputs.webhook_url }}

--- a/.github/workflows/sync-pr-ls.yml
+++ b/.github/workflows/sync-pr-ls.yml
@@ -1,16 +1,11 @@
-name: Sync PR LS
+name: Sync merged PR to Label Studio backend
 
 on:
   pull_request_target:
     types:
-      - opened
       - closed
-      - converted_to_draft
-      - ready_for_review
-      - synchronize
     branches:
       - master
-      - 'ls-release/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -21,7 +16,7 @@ env:
 jobs:
   sync:
     name: "Sync"
-    if: startsWith(github.head_ref, 'fb-')
+    if: ${{ github.event.pull_request.merged }} == true
     runs-on: ubuntu-latest
     steps:
       - uses: hmarr/debug-action@v2.1.0
@@ -32,16 +27,14 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         with:
-          github-token: ${{ secrets.GIT_PAT }}
+          github-token: ${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}
           script: |
             const { repo, owner } = context.repo;
             const [pr_owner, pr_repo] = '${{ github.event.pull_request.head.repo.full_name || github.repository }}'.split('/');
             let event_action = '${{ github.event.action }}'
             let commit_sha = '${{ github.event.pull_request.head.sha }}'
-            if (${{ github.event.pull_request.merged }}) {
-              event_action = 'merged'
-              commit_sha = '${{ github.sha }}'
-            }
+            event_action = 'merged'
+            commit_sha = '${{ github.sha }}'
             const getCommitResponse = await github.rest.repos.getCommit({
               owner: pr_owner,
               repo: pr_repo,

--- a/.github/workflows/sync_to_release.yml
+++ b/.github/workflows/sync_to_release.yml
@@ -27,4 +27,7 @@ jobs:
           git merge origin/master --no-edit -m 'Merge master into release branch in run id ${{github.run_id}}'
           git push
       - name: Notify Slack on failure
+        if: failure()
         uses: ./.github/actions/notify_slack
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary:
Updating the backend workflow sync to work with our repository. I changed it to fire only when PRs are merged to our main branch. Also fixing the slack notify action.

Issue: https://khanacademy.atlassian.net/browse/DI-529

## Test plan:
- will test it after backend change merged (no way to target non-default branch): https://github.com/Khan/label-studio/pull/4