### PR TITLE
MathJax: Add condition for Math expression parsing

### DIFF
--- a/src/examples/rich_text_table/tasks.json
+++ b/src/examples/rich_text_table/tasks.json
@@ -1,7 +1,7 @@
 [
     {
         "data": {
-            "text": "[[\"Asking question?<a href=\\\"javascript:alert('pwned')\\\">click</a>\", \"Answer! Look at some LaTex\\n\\n\\\\(\\\\dfrac{1}{2k - 6} = \\\\dfrac{1}{3}\\\\) and \\\\(\\\\dfrac{1.5}{2k - 6} = \\\\dfrac{1}{3}\\\\)\\n\\n\"], [\"Asking more question in LaTex?\\\\(\\\\dfrac{2}{2k - 6} = \\\\dfrac{1}{3}\\\\)\", \"More LaTex!\\n\\n\\\\(\\\\dfrac{3}{2k - 6} = \\\\dfrac{1}{3}\\\\)\\n\\n\"]]"
+            "text": "[[\"Asking question?<a href=\\\"javascript:alert('pwned')\\\">click</a>\", \"Answer! Look at some LaTex\\n\\n\\\\(\\\\dfrac{1}{2k - 6} = \\\\dfrac{1}{3}\\\\) and \\\\(\\\\dfrac{1.5}{2k - 6} = \\\\dfrac{1}{3}\\\\)\\n\\n\"], [\"Asking more question in LaTex?\\n\\n\\\\[\\n\\\\begin{array}{r}\\n  3.050 \\\\\\\\\\n- 0.338 \\\\\\\\\\n\\\\hline\\n\\\\end{array}\\n\\\\]\\n\\n\", \"More LaTex!\\n\\n\\\\(\\\\dfrac{3}{2k - 6} = \\\\dfrac{1}{3}\\\\)\\n\\n\"]]"
         },
         "predictions": [
             {

--- a/src/tags/object/RichText/table.js
+++ b/src/tags/object/RichText/table.js
@@ -32,7 +32,7 @@ import { HtxRichText } from './view';
 const MATHJAX_MARKER = '$';
 
 // Extract math from conversation, alternate between math and non-math
-// Khanmigo uses "\(.*?\)" and  as the marker for math
+// Khanmigo uses "\(.*?\)" and "\[.*?\]" as the marker for math
 // For example, "What is \(2 + 2\)?" will split into ["What is ", "2 + 2", "?"]
 const parseConvoWithMath = (str) => {
   // About the capture group:  a cool behaviour of str.split is that if there's

--- a/src/tags/object/RichText/table.js
+++ b/src/tags/object/RichText/table.js
@@ -138,9 +138,16 @@ const renderTableValue = (val) => {
 
 // We need to trigger MathJax typeset after the component is mounted
 // See https://docs.mathjax.org/en/latest/advanced/typeset.html
+//
 // As the document suggest above, we need to ensure that only one typeSet
 // function is running at one time.  We use the promise to ensure that the
 // typeset is only run once at a time.
+//
+// TODO: We should fix this in a better way.  This is executed via the useEffect
+// within the <MathJax/> component However as we are rendering the MathJax
+// component dynamically, somehow the useEffect is not triggered.  So we pass
+// this to componentDidMount of the RichTextPieceView component.  This is also
+// why the `renderMode=pre` would not work.
 let typesetPromise = null;
 
 const triggerMathJaxTypeset = () => {
@@ -153,10 +160,20 @@ const triggerMathJaxTypeset = () => {
     // this dynamically.
     if (typeof window?.MathJax?.typesetPromise !== 'function') return;
 
-    typesetPromise = window?.MathJax?.typesetPromise();
-    typesetPromise.finally(() => {
+    typesetPromise = window.MathJax.typesetPromise();
+
+    typesetPromise.catch((err) => {
+      console.error('MathJax Typeset failed:', err);
+      // We have seen this happen on Firefox, where the typeset fails.
+      // Best bet is to clear the typeset and try again.
+      window.MathJax.typesetClear();
+      typesetPromise = null;
+      triggerMathJaxTypeset();
+    }).then(() => {
+      console.log('MathJax Typeset success!');
       typesetPromise = null;
     });
+
   }, 100);
 };
 

--- a/src/tags/object/RichText/table.js
+++ b/src/tags/object/RichText/table.js
@@ -32,13 +32,13 @@ import { HtxRichText } from './view';
 const MATHJAX_MARKER = '$';
 
 // Extract math from conversation, alternate between math and non-math
-// Khanmigo uses "\(.*?\)" as the marker for math
+// Khanmigo uses "\(.*?\)" and  as the marker for math
 // For example, "What is \(2 + 2\)?" will split into ["What is ", "2 + 2", "?"]
 const parseConvoWithMath = (str) => {
   // About the capture group:  a cool behaviour of str.split is that if there's
   // capturing group, the group is captured into the group, which is perfect
   // for us!
-  const mathRegex = /\\\((.*?)\\\)/g;
+  const mathRegex = /\\[([](.*?)\\[)\]]/sg;
 
   return str.split(mathRegex);
 };


### PR DESCRIPTION
## Summary:
We previously thought (and Khanmigo is prompted) that expression
should use `\(...\)` - but in real life we also have seen `\[...\]`
for the wrapping of MathJax.

This is a simple fix for that, as well as adding a test case for it
in our task.json ensure it works.

This also fixes an issue for Firefox when we see browser misrendering,
which we can retry by `clearTypeset`.

Test Plan:

Run `yarn start` to ensure that expression display, as well as highlighting
works with the other type of expressions.

<img width="1107" alt="image" src="https://github.com/user-attachments/assets/640bbae2-046a-41c3-a929-0973f98a5409">
