### PR TITLE
Adding next button to the labeling interface

### DIFF
--- a/src/components/BottomBar/Controls.js
+++ b/src/components/BottomBar/Controls.js
@@ -31,7 +31,7 @@ const controlsInjector = inject(({ store }) => {
 
 export const Controls = controlsInjector(observer(({ store, history, annotation }) => {
   const isReview = store.hasInterface('review');
-  
+
   const historySelected = isDefined(store.annotationStore.selectedHistory);
   const { userGenerate, sentUserGenerate, versions, results, editable: annotationEditable } = annotation;
   const buttons = [];
@@ -40,10 +40,10 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
 
   const disabled = !annotationEditable || store.isSubmitting || historySelected || isInProgress;
   const submitDisabled = store.hasInterface('annotations:deny-empty') && results.length === 0;
-  
+
   const buttonHandler = useCallback(async (e, callback, tooltipMessage) => {
     const { addedCommentThisSession, currentComment, commentFormSubmit } = store.commentStore;
-    
+
     if (isInProgress) return;
     setIsInProgress(true);
     if(addedCommentThisSession){
@@ -57,10 +57,10 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
     }
     setIsInProgress(false);
   }, [
-    store.rejectAnnotation, 
-    store.skipTask, 
-    store.commentStore.currentComment, 
-    store.commentStore.commentFormSubmit, 
+    store.rejectAnnotation,
+    store.skipTask,
+    store.commentStore.currentComment,
+    store.commentStore.commentFormSubmit,
     store.commentStore.addedCommentThisSession,
     isInProgress,
   ]);
@@ -166,6 +166,16 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
 
       buttons.push(button);
     }
+
+    buttons.push(
+      <ButtonTooltip key="next" title="Next">
+        <Button aria-label="next" onClick={async () => {
+          store.nextTaskInList();
+        }}>
+          Next Task
+        </Button>
+      </ButtonTooltip>,
+    );
   }
 
   return (

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -22,7 +22,7 @@ import AnnotationStore from './Annotation/store';
 import Project from './ProjectStore';
 import Settings from './SettingsStore';
 import Task from './TaskStore';
-import { UserExtended } from './UserStore'; 
+import { UserExtended } from './UserStore';
 import { UserLabels } from './UserLabels';
 import { FF_DEV_1536, FF_DEV_2715, FF_LLM_EPIC, FF_LSDV_4620_3_ML, FF_LSDV_4998, isFF } from '../utils/feature-flags';
 import { CommentStore } from './Comment/CommentStore';
@@ -758,6 +758,20 @@ export default types
       await getEnv(self).events.invoke('nextTask');
     }
 
+    // nextTask will only call the next task in taskHistroy.  We need to
+    // invoke the next task in the whole task list.
+    function nextTaskInList() {
+      // TODO: we should find better way to access the dataManager's Mobx Store
+      const taskList = window.dataManager.store.taskStore.list;
+      const thisTaskIdx = taskList.findIndex((x) => x.id === self.task.id);
+
+      if (thisTaskIdx === -1 || thisTaskIdx === taskList.length - 1) {
+        console.warn('nextTaskInList: No next task found!');
+        return;
+      }
+      getEnv(self).events.invoke('nextTask', taskList[thisTaskIdx + 1].id);
+    }
+
     function nextTask() {
       if (self.canGoNextTask) {
         const { taskId, annotationId } = self.taskHistory[self.taskHistory.findIndex((x) => x.taskId === self.task.id) + 1];
@@ -826,6 +840,7 @@ export default types
 
       addAnnotationToTaskHistory,
       nextTask,
+      nextTaskInList,
       prevTask,
       postponeTask,
       beforeDestroy() {

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -760,6 +760,9 @@ export default types
 
     // nextTask will only call the next task in taskHistroy.  We need to
     // invoke the next task in the whole task list.
+    //
+    // Note: the list only include the tasks that are shown in the datamanager
+    // table (e.g. in the currrent tab).
     function nextTaskInList() {
       // TODO: we should find better way to access the dataManager's Mobx Store
       const taskList = window.dataManager.store.taskStore.list;


### PR DESCRIPTION
## Summary:
To make labelling easier, provide the Next task button to allow labellers to iterate through items.

Note that normally one would use the "Label tasks as displayed" feature, but that turns out to be
not working as expected - at most it will give label of ~10 tasks from our testing.

Note that we create a separate button, instead of part of the "Submit" because submitting require
an async operation to data manager which makes it hard to know when that's done, before jumping
to next task.

## Test Plan

Render the interface, and you should see the next button provided.

<img width="982" alt="image" src="https://github.com/user-attachments/assets/834066d1-9ecb-46c4-ab5c-8414f21c7e42">

